### PR TITLE
count() error fix

### DIFF
--- a/base.php
+++ b/base.php
@@ -36,7 +36,7 @@
             <?php if (!is_front_page()): ?>
             <div class="container" id="#mainContent" tabindex="-1">
                 <?php
-                if(isset($fields['multipage_menu']) && $fields['multipage_menu'] !== false && (count($field['multipage_menu']) > 0)){
+                if(isset($fields['multipage_menu']) && !(empty($fields['multipage_menu'])) ){
                     set_query_var('multipage_menu', wp_get_nav_menu_items($fields['multipage_menu']));
                     get_template_part('templates/content-page-submenu');
                 }

--- a/base.php
+++ b/base.php
@@ -27,7 +27,7 @@
     <div role="document">
       <?php
         $fields = $fields = function_exists('get_fields') ? get_fields() : null;
-        if ((count($fields['jumbotron_header']) > 0)){
+        if (!empty($fields['jumbotron_header'])){
             get_template_part('templates/jumbotron-header');
         }
       ?>


### PR DESCRIPTION
Fixing my earlier fix! The PHP error log in the WP dashboard was throwing a warning every time the homepage was visited. Oops! Changed the count function to an empty function, and all is well. 👍